### PR TITLE
builds the obs client the non-deprecated way

### DIFF
--- a/src/test/java/com/implisense/cloud/otc/obs/OtcObsExample.java
+++ b/src/test/java/com/implisense/cloud/otc/obs/OtcObsExample.java
@@ -15,7 +15,7 @@ public class OtcObsExample {
         String secretKey = "........................................";
         AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
-        AmazonS3 obs = OtcObsClient.create(credentials);
+        AmazonS3 obs = OtcObsClientFactory.create(credentials);
 
         /*
          * This example shows a simple workflow using the object storage


### PR DESCRIPTION
in order to stop log useless messages from `com.amazonaws.internal.DefaultServiceEndpointBuilder` like 

```{obs, eu-de} was not found in region metadata, trying to construct an endpoint using the standard pattern for this region: 'obs.eu-de.otc.t-systems.com'.``` from appearing, build the S3Client using the `AmazonS3ClientBuilder`, which offers all options required to configure the client.